### PR TITLE
Improve onboarding chat composer keyboard handling

### DIFF
--- a/src/components/onboarding/ChatQuickActions.tsx
+++ b/src/components/onboarding/ChatQuickActions.tsx
@@ -17,7 +17,15 @@ export const ChatQuickActions: React.FC<Props> = ({ actions, onSelect, disabled 
   if (actions.length === 0) return null;
 
   return (
-    <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 12 }}>
+    <View
+      style={{
+        flexDirection: "row",
+        flexWrap: "wrap",
+        gap: 8,
+        marginTop: 4,
+        marginBottom: 8,
+      }}
+    >
       {actions.map((action) => (
         <Pressable
           key={action.id}


### PR DESCRIPTION
## Summary
- animate the onboarding chat composer to follow the system keyboard and auto-scroll the thread when the keyboard appears
- float the quick actions and text input in a shared bottom sheet with reduced spacing for a compact Instagram-like layout across both AI onboarding steps
- tweak quick-action chip spacing so the preset shortcuts sit closer to the composer without leaving a white gap

## Testing
- npm run lint *(fails: Missing script "lint" defined in package.json)*
- npx tsc --noEmit *(fails: existing type errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_b_68d19cdbf9e88329b208c631647c7210